### PR TITLE
Segregation into modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./css/style.css">
     <title>Document</title>
-    <script src="./js/pure_canvas.js" defer="1"></script>
+    <script src="./js/pure_canvas.js" type="module" defer="1"></script>
     <link rel="shortcut icon" href="favicon.png?76294" type="image/x-icon">
 </head>
 

--- a/js/pure_canvas.js
+++ b/js/pure_canvas.js
@@ -1,120 +1,39 @@
-"use strict";
+import Table from "./pure_canvas/table.mjs";
+import Ball from "./pure_canvas/ball.mjs";
+// import config from "./pure_canvas/config.mjs";
 
 (function() {
     const canvas = document.getElementById("canvas001");
     const ctx = canvas.getContext("2d");
 
-    const table = {
-        size: {width: 360, height: 200},
-        color: "#bbb",
-        borders: {color: "#333", thickness: 4},
-        location: {x:120, y:40},
-        wall_friction_loss: 0.6,
-    };
-    const ball = {
-        color: "#111",
-        table: table,
-        radius: 8,
-        location: {x:200, y:50},
-        speed: {x: 0.3, y:1},
-    }
-    ball.absolute_location = function() {
-        let tbl_loc = this.table.location;
-        let tbl_b_thick = this.table.borders.thickness;
-        return {
-            x: this.location.x + tbl_loc.x + tbl_b_thick, 
-            y: this.location.y + tbl_loc.y + tbl_b_thick}
-    };
-    ball.draw = function() {
-        ctx.beginPath();
-        ctx.fillStyle = this.color;
-        let loc = this.absolute_location();
-        ctx.arc(loc.x, loc.y, this.radius, 0, Math.PI *2);
-        ctx.fill()
-        ctx.closePath();
-    };
+    const table = new Table({x:120, y:40}
+        , {width: 360, height: 200}
+        );
 
-    function draw_table() {
-        ctx.beginPath();
-        
-        ctx.fillStyle = table.borders.color;
-        ctx.fillRect(
-            table.location.x,
-            table.location.y,
-            table.size.width + 2*table.borders.thickness,
-            table.size.height + 2*table.borders.thickness,
-        );
-        ctx.fillStyle = table.color;
-        ctx.fillRect(
-            table.location.x + table.borders.thickness,
-            table.location.y + table.borders.thickness,
-            table.size.width,
-            table.size.height,
-        );
-        ctx.closePath();
-    }
+    const ball = table.locate(Ball, {x:20, y:50}); //new Ball({x:200, y:50});
+    ball.speed = {x: 0.3, y:1};
 
     function animation() {
-        let x = table.location.x;
-        let y = table.location.y;
-        let w = table.size.width + 2*table.borders.thickness;
-        let h = table.size.height + 2*table.borders.thickness;
+        let {x, y} = table.location;
+        let bt = table.borders.thickness;
+        let {width: w, height:h} = table.size;
+        w += 2*bt;
+        h += 2*bt;
         ctx.clearRect(x, y, w, h);
-        draw_table();
-        ball.draw();
-        ball.location.x += ball.speed.x;
-        ball.location.y += ball.speed.y;
-        let b_loc = ball.location;
-        if(b_loc.x >= table.size.width - ball.radius) {
-            ball.speed.x *= -table.wall_friction_loss;
-            ball.location.x = table.size.width - ball.radius;
-        } else if (b_loc.x <= 0 + ball.radius) {
-            ball.speed.x *= -table.wall_friction_loss;
-            ball.location.x = 0 + ball.radius;
-        }
-        if (b_loc.y >= table.size.height - ball.radius) {
-            ball.speed.y *= -table.wall_friction_loss;
-            ball.location.y = table.size.height - ball.radius;
-        } else if (b_loc.y <= 0 + ball.radius) {
-            ball.speed.y *= -table.wall_friction_loss;
-            ball.location.y = 0 + ball.radius;
-        }
-        // friction_influence(ball);
-
-
+        table.draw(ctx);
+        ball.tick();
 
         requestAnimationFrame(animation);
-    }
-
-    function friction_influence(ball) {
-        let friction = table.friction;
-        if(Math.abs(ball.speed.x) <= friction) {
-            ball.speed.x == 0
-        }
-        if (ball.speed.x > 0) {
-            ball.speed.x -= friction
-        } else if (ball.speed.x < 0) {
-            ball.speed.x += friction
-        }
-
-        if(Math.abs(ball.speed.y) <= friction ) {
-            ball.speed.y == 0
-        } else {
-
-        }
-
-        if (ball.speed.y > 0) {
-            ball.speed.y -= friction
-        } else if (ball.speed.y < 0) {
-            ball.speed.y += friction
-        }
     }
 
     canvas.onmouseup = function (e) {
         let mx = e.clientX - canvas.getBoundingClientRect().x;
         let my = e.clientY - canvas.getBoundingClientRect().y;
-        ball.speed.x = -(mx - ball.location.x)/8;
-        ball.speed.y = -(my - ball.location.y)/8;
+
+        let {x, y} = ball.absolute_location;
+
+        ball.speed.x = -(mx - x)/8;
+        ball.speed.y = -(my - y)/8;
     }
     
     

--- a/js/pure_canvas/ball.mjs
+++ b/js/pure_canvas/ball.mjs
@@ -1,0 +1,49 @@
+import config from "./config.mjs";
+export default class Ball {
+    constructor(location, additional_parameters) {
+        this.location = location;
+        config.init_defaults(this, config.defaults.ball, additional_parameters);
+    }
+
+    get absolute_location() {
+        let {x, y} = this.location;
+        if ("container" in this) {
+            let {x:cx, y:cy} = this.container.content_location
+            x += cx;
+            y += cy;
+        }
+        return {x:x, y:y}
+    }
+
+    draw(ctx) {
+        let {x, y} = this.absolute_location;
+        ctx.beginPath();
+        ctx.fillStyle = this.color;
+        ctx.arc(x, y, this.radius, 0, Math.PI *2);
+        ctx.fill()
+        ctx.closePath();
+    };
+
+    tick() {
+        this.location.x += this.speed.x;
+        this.location.y += this.speed.y;
+        let {x, y} = this.location;
+        let wall_friction_loss = config.environment.speed_loss_on_impact_multiplier
+        let {width: w, height:h} = this.container.size;
+
+        if(x >= w - this.radius) {
+            this.speed.x *= -wall_friction_loss;
+            this.location.x = w - this.radius;
+        } else if (x <= 0 + this.radius) {
+            this.speed.x *= -wall_friction_loss;
+            this.location.x = 0 + this.radius;
+        }
+        if (y >= h - this.radius) {
+            this.speed.y *= -wall_friction_loss;
+            this.location.y = h - this.radius;
+        } else if (y <= 0 + this.radius) {
+            this.speed.y *= -wall_friction_loss;
+            this.location.y = 0 + this.radius;
+        }
+    }
+}

--- a/js/pure_canvas/config.mjs
+++ b/js/pure_canvas/config.mjs
@@ -1,0 +1,28 @@
+const config = {
+    defaults: {
+        table: {
+            color: "#bbb",
+            borders: {color: "#333", thickness: 4},
+        },
+        ball: {
+            color: "#111",
+            radius: 8
+        }
+    },
+    environment: {
+        speed_loss_on_impact_multiplier: 0.6
+    }
+    
+};
+config.init_defaults = function(obj, defaults, custom_defaults) {
+    for (const prop in custom_defaults) {
+        obj[prop] = custom_defaults[prop]
+    }
+    for (const prop in defaults) {
+        if (prop in obj) {
+            continue;
+        }
+        obj[prop] = defaults[prop]
+    }
+};
+export default config;

--- a/js/pure_canvas/table.mjs
+++ b/js/pure_canvas/table.mjs
@@ -1,0 +1,44 @@
+import config from "./config.mjs";
+export default class Table {
+    constructor(location, size, additional_parameters) {
+        this.location = location;
+        this.size = size;
+        config.init_defaults(this, config.defaults.table, additional_parameters);
+        this.content = [];
+    }
+
+    locate(Obj, location, additional_parameters) {
+        let obj = new Obj(location, additional_parameters);
+        obj.container = this;
+        this.content.push(obj);
+        return obj;
+    }
+
+    get content_location() {
+        let {x, y} = this.location;
+        let bt = this.borders.thickness;
+        x += bt;
+        y += bt;
+        return {x:x, y:y}
+    }
+
+    draw(ctx) {
+        let {x, y} = this.location; 
+        let {width: w, height:h} = this.size;
+        let bt = this.borders.thickness;
+
+        ctx.beginPath();
+        
+        ctx.fillStyle = this.borders.color;
+        ctx.fillRect(x, y, w + 2*bt, h + 2*bt);
+
+        ctx.fillStyle = this.color;
+        ctx.fillRect(x + bt, y + bt, w, h);
+        ctx.closePath();
+
+        for (const obj of this.content) {
+            obj.draw(ctx);
+        }
+
+    }
+}


### PR DESCRIPTION
I've spread the code from `pure_canvas.js` into several modules:
- `config.mjs` aggregates the default parameters + a function `config.init_defaults` for easy applying the defaults to objects
- `table.mjs` contains all the functionality related to the playing table entity
- `ball.mjs` - does the same for the ball

\+ Also the mouse click responsiveness is improved 🙂

These two entities (`table` and `ball`) are now formed as classes. 
Each of them describes the way of how it should be drawn via the `draw` method.

##  `class Table`
#### `locate`
Locates objects (only `balls` are available for now) inside its working area.
#### `content_location`
Returns the upper left corner of the working area.
#### `this.content`
Stores all the objects, located in the working area.
#### `draw(ctx)`
Draws the table, and then draws all its `this.content` by invoking their `draw(ctx)` method.


## `class Ball`
#### `absolute_location`
Returns the global location (`this.location` keeps location relative to the table's working area).

#### `draw(ctx)`
Draws the ball.

#### `tick()`
Changes the position of the ball according to its speed and some other factors.
